### PR TITLE
New API to query upto a specific length of quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,34 @@ Content-Length: 67
 }
 ```
 
+### `/length/{len}`
+
+##### GET:
+
+Where {len} is the maximum length of a quote that the user needs.
+Responds with a JSON body of the quotes which are lesser than or equal 
+to {len}.
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Date: Mon, 04 Jun 2018 09:46:36 GMT
+Content-Length: 67
+
+[
+    {
+        "quote": "Decimated!",
+        "uuid": "96fc33e1-ee31-403c-a932-c788e579dc34",
+        "score": 0
+    },
+    {
+        "quote": "Destroyed!",
+        "uuid": "d5ff203c-3f8b-4c35-b74f-71565ae60dd4",
+        "score": 0
+    }
+]
+```
+
 ### `/uuid/{uuid}/like`
 
 ##### POST:

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"unicode"
+	"strconv"
 
 	"github.com/bruno-chavez/restedancestor/database"
 	"github.com/bruno-chavez/restedancestor/quotes"
@@ -71,6 +73,35 @@ func Senile(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
 	err := writeResponse(w, joinedQuote)
 	if err != nil {
 		log.Fatal(err)
+	}
+}
+
+func Length(w http.ResponseWriter, _ *http.Request, p httprouter.Params) {
+
+	log.Println("testing length")
+	word := p.ByName("len")
+
+	for _, r := range word { 
+		err := unicode.IsLetter(r) 
+		if err {
+			log.Fatal("Not a number")
+			return
+		}
+    }
+	
+	length, _ := strconv.ParseUint(word, 10, 32)
+	qs := repo.AllByLengthLessThanOrEqual(length)
+
+	if len(qs) != 0 {
+		err := writeResponse(w, qs)
+		if err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		err := writeNotFound(w, word)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ func main() {
 	router.GET("/senile", handlers.Senile)
 	router.GET("/search/:word", handlers.Search)
 	router.GET("/top", handlers.Top)
-
+	router.GET("/length/:len", handlers.Length)
 	//uuid routes
 	router.GET("/uuid/:uuid/find", handlers.Find)
 	router.POST("/uuid/:uuid/like", handlers.Like)

--- a/quotes/repository.go
+++ b/quotes/repository.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"log"
 	"strings"
+	"strconv"
+	"fmt"
 
 	"github.com/bruno-chavez/restedancestor/database"
 	uuid "github.com/satori/go.uuid"
@@ -72,6 +74,29 @@ func (r Repository) AllByWord(w string) []Quote {
         FROM indexes i INNER JOIN indexes_quotes iq ON i.id_index = iq.id_index INNER JOIN quotes q ON iq.id_quote = q.id_quote
         WHERE word = ?
         ORDER BY q.id_quote`, w)
+	if err != nil {
+		log.Fatal("Malformed SQL :" + err.Error())
+	}
+
+	// closes db connection
+	defer func() {
+		err := stmt.Close()
+		if err != nil {
+			log.Fatal(err)
+		}
+	}()
+
+	return buildSliceFromData(stmt)
+}
+
+// AllLengthLessThanOrEqual returns all quotes with length less than or equal to
+func (r Repository) AllByLengthLessThanOrEqual(length uint64) []Quote {
+	
+	str := fmt.Sprintf("SELECT id_quote, content, score, uuid FROM quotes WHERE length(content)<=%d", length)
+
+	stmt, err := r.db.Prepare(str)
+
+	log.Println(strconv.FormatUint(length, 10))
 	if err != nil {
 		log.Fatal("Malformed SQL :" + err.Error())
 	}


### PR DESCRIPTION
This new API will allow a user to query quotes which have a length up to a value specified by the user.

For example - /length/10 will return all quotes which have their length less than or equal to 10.